### PR TITLE
Refactor Twitter client initialization and server route setup

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -34,8 +34,9 @@ func (s *Server) Start() error {
 // SetupRoutes sets up the routes for the server
 func (s *Server) SetupRoutes(authClient *twitter.Client) {
 	authMiddleware := middleware.AuthMiddleware(s.secret)
-	s.router.Use(authMiddleware).GET("/", loginHandler(authClient))
-	s.router.Use(authMiddleware).POST("/refresh", refreshTokenHandler(authClient))
+	s.router.Use(authMiddleware)
 
+	s.router.GET("/", loginHandler(authClient))
+	s.router.POST("/refresh", refreshTokenHandler(authClient))
 	s.router.GET("/callback", callbackHandler(authClient))
 }

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ func main() {
 
 	serverAddr := fmt.Sprintf(":%s", cfg.Port)
 
-	authClient := twitter.NewClient(cfg.TwitterClientID, cfg.TwitterClientSecret, cfg.TwitterRedirectURI)
+	authClient := twitter.NewClient(cfg.TwitterClientID, cfg.TwitterClientSecret, fmt.Sprintf("%s?api_key=%s", cfg.TwitterRedirectURI, cfg.APIKey))
 
 	server := api.NewServer(cfg.Port, cfg.APIKey)
 	server.SetupRoutes(authClient)

--- a/twitter/oauth.go
+++ b/twitter/oauth.go
@@ -71,7 +71,7 @@ func (c *Client) GetAuthURL() (string, error) {
 // ExchangeCodeForToken exchanges auth code for access token
 func (c *Client) ExchangeCodeForToken(ctx context.Context, code string) (models.TokenResponse, error) {
 	data := fmt.Sprintf(
-		"grant_type=authorization_code&code=%s&client_id=%s&redirect_uri=%s/callback&code_verifier=%s",
+		"grant_type=authorization_code&code=%s&client_id=%s&redirect_uri=%s&code_verifier=%s",
 		code,
 		c.clientID,
 		c.redirectURI,


### PR DESCRIPTION
- Updated main.go to include API key in the redirect URI for Twitter client initialization.
- Simplified middleware usage in api/server.go by separating middleware application from route definitions.
- Adjusted oauth.go to correct the format of the authorization URL by including the redirect URI without hardcoding.